### PR TITLE
33 extraction info bug

### DIFF
--- a/src/file_info.ts
+++ b/src/file_info.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import {basename} from 'path';
-import {extract, decomp} from "./extension";
+import {extract} from "./extension";
 
 /**
  * Class Name: ExtractionInfo


### PR DESCRIPTION
### FIX: ExtractionInfo Bug

**Summary**
The previous line caused the original workspace folder to be replaced with the archive directory in the temp folder. This is what caused the `.vscode` folder to appear in there. This new line just adds the archive directory to be added to the array of all the workspace folders. The `.vscode` folder is only added to the first workspace folder which is the one that the one where the archive comes from. 

Closes #33 