### PR TITLE
[#38] zip now creates missing directories.

### DIFF
--- a/src/zip/zip.ts
+++ b/src/zip/zip.ts
@@ -90,6 +90,9 @@ export function extract_zip(path: string): ExtractionInfo | null {
 					// if the file is zero size it's probably a directory, so make a directory.
 					fs.mkdirSync(tmp.create_temp_dir() + "/" + path_object.name + "/" + filename, {recursive: true});
 				} else {
+					if (!fs.existsSync(tmp.create_temp_dir() + "/" + path_object.name + "/" + pathlib.parse(filename.toString()).dir)) {
+						fs.mkdirSync(tmp.create_temp_dir() + "/" + path_object.name + "/" + pathlib.parse(filename.toString()).dir, {recursive: true});
+					}
 					// otherwise it was actually stored uncompressed.
 					fs.writeFileSync(tmp.create_temp_dir() + "/" + path_object.name + "/" + filename, data);
 				}
@@ -107,6 +110,9 @@ export function extract_zip(path: string): ExtractionInfo | null {
 					}
 				}
 				if (infl) {
+					if (!fs.existsSync(tmp.create_temp_dir() + "/" + path_object.name + "/" + pathlib.parse(filename.toString()).dir)) {
+						fs.mkdirSync(tmp.create_temp_dir() + "/" + path_object.name + "/" + pathlib.parse(filename.toString()).dir, {recursive: true});
+					}
 					fs.writeFileSync(tmp.create_temp_dir() + "/" + path_object.name + "/" + filename, infl);
 				}
 				break;


### PR DESCRIPTION
the windows zip tool omitted a record for a directory that caused that
directory's contents to not be extracted. now if a path contains a
directory and the directory doesn't exist the directory is created.

closes #38 