### PR TITLE
Extraction info menu

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,7 +28,7 @@ export function activate(context: vscode.ExtensionContext) {
 		// Saves the file path of the file
 		let path = uri.fsPath;
 		let file_info = new ExtractionInfo(path);
-		file_info.load;
+
 		
 		//creates webview panel
 		const panel = vscode.window.createWebviewPanel('Info', path, vscode.ViewColumn.One,  {enableScripts: true});
@@ -46,11 +46,9 @@ export function activate(context: vscode.ExtensionContext) {
 				case 'extract':
 					logExtract(path);
 					extract_file_at_path(path);
-					file_info.load;
 					updateWebview(file_info.decompressedSize, file_info.extractedPath);
 					return;
 				case 'file':
-					file_info.load;
 					let uri = vscode.Uri.file(file_info.extractedPath);
 					vscode.commands.executeCommand('vscode.openFolder', uri, true);
 					return;
@@ -147,6 +145,7 @@ function getWebviewContent(size: number, path: string, eSize: number) {
 				}
 				function extract(){
 					var text = "Extracted File Size: "+${eSize}+" bytes";
+					vscode.postMessage({command: 'extract'})
 					document.getElementById("size").innerHTML = text;
 				}
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 import { extract_file_at_path } from './file_types';
 import {Category,CategoryLogger,CategoryServiceFactory,CategoryConfiguration,LogLevel} from "typescript-logging";
 import {ExtractionInfo} from './file_info';
+import * as pathlib from 'path';
 
 //changes the default output to INFO instead of ERR
 CategoryServiceFactory.setDefaultConfiguration(new CategoryConfiguration(LogLevel.Info));
@@ -45,8 +46,8 @@ export function activate(context: vscode.ExtensionContext) {
 				switch (message.command) {
 				case 'extract':
 					logExtract(path);
+					panel.dispose();
 					extract_file_at_path(path);
-					updateWebview(file_info.decompressedSize, file_info.extractedPath);
 					return;
 				case 'file':
 					let uri = vscode.Uri.file(file_info.extractedPath);
@@ -128,10 +129,10 @@ function getWebviewContent(size: number, path: string, eSize: number) {
 			<div style="font-size:24px">Unextracted File Size: ${size} bytes</div><br>
 			<div id="size" style="font-size:24px"></div><br>
 			<br>
-			<button class="button button" id="location">File Location</button>
-			<br>
-			
+			<p>Running extract will close this Webview.</p>
 			<button class="button button" id="extract">Extract Files</button>
+			<br>
+			<div id="but"></div>
 
 			<script>
 			const vscode = acquireVsCodeApi();
@@ -139,6 +140,7 @@ function getWebviewContent(size: number, path: string, eSize: number) {
 				if(${eSize}>0){
 					var text = "Extracted File Size: "+${eSize}+" bytes";
 					document.getElementById("size").innerHTML = text;
+					document.getElementById("but").innerHTML = '<button class="button button" id="location" onclick=file()>Open File In New Window</button>';
 				}
 				function file(){
 					vscode.postMessage({command: 'file'})
@@ -146,11 +148,8 @@ function getWebviewContent(size: number, path: string, eSize: number) {
 				function extract(){
 					var text = "Extracted File Size: "+${eSize}+" bytes";
 					vscode.postMessage({command: 'extract'})
-					document.getElementById("size").innerHTML = text;
 				}
 
-				var loc = document.getElementById('location');
-				loc.addEventListener('click', file, false, false);
 				
 				var ex = document.getElementById('extract');
 				ex.addEventListener('click', extract, false, false);

--- a/src/file_info.ts
+++ b/src/file_info.ts
@@ -255,7 +255,6 @@ export class ExtractionInfo{
     public load(path: string): number{
         if(!fs.existsSync(path)){
             //Doesn't exist
-            vscode.window.showErrorMessage("File at " + path + " does not exist.");
             return -1;
         }
 


### PR DESCRIPTION
Info page now closes after the file extraction as well update the page with extracted file size and a button that will open the extracted file in a new window. It now also shows a warning above the "Extract Files" button that says the window will close after extraction.

Closes #49 

Below are Screenshots of the UI
![unextracted](https://user-images.githubusercontent.com/31966864/87880435-a573fd00-c9bf-11ea-9c4f-74d6f571104d.PNG)
![extracted](https://user-images.githubusercontent.com/31966864/87880436-a86eed80-c9bf-11ea-9487-755dc1a9e9a8.PNG)

