### PR TITLE
[#18] lzma & 7z

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,22 @@
 {
 	"name": "archive-browser",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"7zip-bin": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.0.3.tgz",
+			"integrity": "sha512-GLyWIFBbGvpKPGo55JyRZAo4lVbnBiD52cKlw/0Vt+wnmKvWJkpZvsjVoaIolyBXDeAQKSicRtqFNPem9w0WYA=="
+		},
+		"7zip-min": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/7zip-min/-/7zip-min-1.1.2.tgz",
+			"integrity": "sha512-CkGc+r0H4rOPsvxHiNb8W3tonGafz+E6pYrqJBIVVMHaJv8cZDY6mGqbrIpsFhoui9bIkLev8MoP/lvy2hjjXA==",
+			"requires": {
+				"7zip-bin": "^5.0.3"
+			}
+		},
 		"@babel/code-frame": {
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
@@ -1172,6 +1185,11 @@
 			"requires": {
 				"chalk": "^2.4.2"
 			}
+		},
+		"lzma": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/lzma/-/lzma-2.3.2.tgz",
+			"integrity": "sha1-N4OySFi5wOdHoN88vx+1/KqSxEE="
 		},
 		"mimic-fn": {
 			"version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,9 @@
 		"vscode-test": "^1.3.0"
 	},
 	"dependencies": {
+		"7zip-min": "^1.1.2",
 		"bzip2": "^0.1.1",
+		"lzma": "^2.3.2",
 		"os": "^0.1.1",
 		"typescript-logging": "^0.6.4"
 	}

--- a/src/lzma/lzma.ts
+++ b/src/lzma/lzma.ts
@@ -1,0 +1,48 @@
+import * as fs from 'fs';
+import * as pathlib from 'path';
+import * as tmp from '../temp_dir';
+import {decomp} from '../extension';
+import {ExtractionInfo} from '../file_info';
+let lzma = require('lzma');
+
+//Declare stuff here
+
+export function extract_lzma(path: string): ExtractionInfo | null {
+    var archive_file: Buffer;
+
+    if(fs.existsSync(path)){
+        archive_file = fs.readFileSync(path);
+    }
+    else{
+        decomp.warn("File at path " + path + "does not exist.");
+        return null;
+    }
+    var temp_path = pathlib.parse(path);
+    var new_path = tmp.create_temp_dir() + '/' + temp_path.name;
+    var infl;
+
+    //Make a new directory in the temp directory if not already there.
+    if(!fs.existsSync(new_path)){
+        fs.mkdirSync(new_path);
+    }
+
+    //Unzip the file
+    try{
+        infl = lzma.decompress(archive_file);
+    }
+    catch(err){
+        decomp.error("Error extracting", err);
+    }
+
+    //Write unzipped buffer to a file
+    fs.writeFileSync(new_path + "/" + temp_path.name, infl);
+
+    //Create an ExtractionInfo object and return
+    var info = new ExtractionInfo(path);
+    info.extractedPath = new_path;
+    let file_stats = fs.statSync(new_path + "/" + temp_path.name);
+    info.decompressedSize = file_stats["size"];
+    info.fileCount = 1;
+
+    return info;
+}


### PR DESCRIPTION
lzma compressed files can be decompressed.
7z archives can be extracted. lzma compression in zips does not work,
apparently it's not the same as lzma compressing a file.

closes #18

this whole project needs an async rewrite because callbacks are garbage.